### PR TITLE
Fix comparison of fixnum array elements

### DIFF
--- a/lib/json-compare/comparer.rb
+++ b/lib/json-compare/comparer.rb
@@ -53,7 +53,7 @@ module JsonCompare
 
       (0..inters).map do |n|
         res = compare_elements(old_array[n], new_array[n])
-        result[:update][n] = res unless res.empty?
+        result[:update][n] = res unless (res.nil? || (res.respond_to?(:empty?) && res.empty?))
       end
 
       # the rest of the larger array
@@ -79,7 +79,7 @@ module JsonCompare
           res = compare_elements(old_hash, new_array[0])
           result[:update][n] = res unless res.empty?
         else
-        result[:append][n] = new_array[n]
+          result[:append][n] = new_array[n]
         end
       end
 

--- a/spec/lib/json-compare_spec.rb
+++ b/spec/lib/json-compare_spec.rb
@@ -105,6 +105,11 @@ describe 'Json compare' do
       }
       result.should eq(expected_result)
     end
+
+    it "should compare arrays of fixnums" do
+      result =  JsonCompare.get_diff([1, 2, 3], [1, 2, 3, 4])
+      result.should eq(:append => { 3 => 4 }, :update => { 3 => 4 })
+    end
   end
 
   describe "keys exclusion" do


### PR DESCRIPTION
Fixnums don't respond to `empty?` so I kept encountering NoMethodErrors.

I'll be happy to update if you plan to accept https://github.com/a2design-company/json-compare/pull/2 beforehand?
