### PR TITLE
check for nil before accesing the hash object

### DIFF
--- a/lib/json-compare/comparer.rb
+++ b/lib/json-compare/comparer.rb
@@ -29,6 +29,8 @@ module JsonCompare
     end
 
     def compare_hashes(old_hash, new_hash)
+      old_hash = old_hash == nil ? {} : old_hash
+      new_hash = new_hash == nil ? {} : new_hash
       keys = (old_hash.keys + new_hash.keys).uniq
       result = get_diffs_struct
       keys.each do |k|


### PR DESCRIPTION
for example this little piece of code show the issue which my patch fix.

require 'json-compare'
arr1 = [{"a"=>"b"}]
arr2= []
JsonCompare.get_diff(arr1,arr2)
