### PR TITLE
reduce range by 1 to fix potential off-by-1 error

### DIFF
--- a/lib/json-compare/comparer.rb
+++ b/lib/json-compare/comparer.rb
@@ -57,7 +57,7 @@ module JsonCompare
 
       result = get_diffs_struct
 
-      (0..inters).map do |n|
+      (0..(inters - 1)).map do |n|
         res = compare_elements(old_array[n], new_array[n])
         result[:update][n] = res unless (res.nil? || (res.respond_to?(:empty?) && res.empty?))
       end


### PR DESCRIPTION
This accounts for counting from 0 in the range, as `inters` is generated from a `length` call which counts from 1. This should fix #9 
