### PR TITLE
README updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Returns the difference between two JSON files.
 
 ## Installation
 
+This gem makes use of a JSON parsing and encoding library for Ruby, [yajl-ruby](https://github.com/brianmario/yajl-ruby)
+
+Make sure that YAJL-Ruby is installed first!
+
 Add this line to your application's Gemfile:
 
     gem 'json-compare'


### PR DESCRIPTION
I updated the README to let developers know that YAJL-Ruby has to be installed first before json-compare can be installed. The other way to go about it would be to include YAJL-Ruby as a runtime dependency in the gemspec of the project. I have created two pull requests for each of them.
