### PR TITLE
Added YAJL-Ruby as a runtime dependency to the project.

### DIFF
--- a/json-compare.gemspec
+++ b/json-compare.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |gem|
   # tests
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', ">= 2.0.0"
-  gem.add_development_dependency 'yajl-ruby'
 
-  #for actual use
-  gem.add_runtime_dependency 'yajl-ruby'
+  #for actual use and tests
+  gem.add_dependency 'yajl-ruby'
 end

--- a/json-compare.gemspec
+++ b/json-compare.gemspec
@@ -19,4 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', ">= 2.0.0"
   gem.add_development_dependency 'yajl-ruby'
+
+  #for actual use
+  gem.add_runtime_dependency 'yajl-ruby'
 end


### PR DESCRIPTION
When someone installs the json compare gem the YAJL Ruby gem is automatically installed as a runtime dependency instead of installing it separately.
