### PR TITLE
Fixed reflexive null case.

### DIFF
--- a/lib/json-compare/comparer.rb
+++ b/lib/json-compare/comparer.rb
@@ -17,7 +17,7 @@ module JsonCompare
         end
         diff = diff_hash if diff_hash.count > 0
       elsif (!is_boolean(old) || !is_boolean(new)) && old.class != new.class
-        diff = new
+        diff = new == nil ? old : new
       elsif old.kind_of? Array
         diff_arr = compare_arrays(old, new)
         diff = diff_arr if diff_arr.count > 0


### PR DESCRIPTION
[twitter-search.zip](https://github.com/a2design-inc/json-compare/files/64772/twitter-search.zip)

A potential bug has been identified.

To illustrate, the attached zip file contains two json files that are nearly identical -- except one contains a null value. Depending on the call string JsonCompare.get_diff(old, new) --OR-- JsonCompare.get_diff(new, old), different answers will result. In one case, the difference is identified, but in the other, an empty array is returned.

This pull request correctly handles the uncaught null case.
