### PR TITLE
Adding option tomatch array elements when comparing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ If you want to exclude some keys from comparison use exclusion param:
     exclusion = ["from_user", "to_user_id"]
     result = JsonCompare.get_diff(old, new, exclusion)
 
+Alternative way for excluding keys from comparison:
+
+    exclusions = ["from_user", "to_user_id"]
+    result = JsonCompare.get_diff(old, new, excluded_key: excluded_keys)
+
+If you want to match array elements by a certain key:
+
+    result = JsonCompare.get_diff(old, new, matching_key: "id")
+
+
 ## Contributing
 
 1. Fork it

--- a/lib/json-compare.rb
+++ b/lib/json-compare.rb
@@ -2,9 +2,13 @@ require 'json-compare/version'
 require 'json-compare/comparer'
 
 module JsonCompare
-  def self.get_diff(old, new, exclusion = [])
+  def self.get_diff(old, new, options = {})
+    if options.kind_of?(Array)
+      options = {excluded_keys: options}
+    end
     comparer = JsonCompare::Comparer.new
-    comparer.excluded_keys = exclusion
+    comparer.excluded_keys = options.delete(:excluded_keys) || []
+    comparer.matching_key = options.delete(:matching_key)
     comparer.compare_elements(old,new)
   end
 end

--- a/lib/json-compare.rb
+++ b/lib/json-compare.rb
@@ -4,7 +4,7 @@ require 'json-compare/comparer'
 module JsonCompare
   def self.get_diff(old, new, options = {})
     if options.kind_of?(Array)
-      options = {excluded_keys: options}
+      options = {:excluded_keys => options}
     end
     comparer = JsonCompare::Comparer.new
     comparer.excluded_keys = options.delete(:excluded_keys) || []

--- a/spec/lib/json-compare_spec.rb
+++ b/spec/lib/json-compare_spec.rb
@@ -129,7 +129,86 @@ describe 'Json compare' do
 
     it "should compare arrays of fixnums" do
       result =  JsonCompare.get_diff([1, 2, 3], [1, 2, 3, 4])
-      result.should eq(:append => { 3 => 4 }, :update => { 3 => 4 })
+      result.should eq(:append => { 3 => 4 })
+    end
+  end
+
+
+  describe 'Arrays Comparison with matching condition' do
+    it "should treat as update" do
+      old = [{id: '123'}]
+      new = [{id: '456'}]
+      result = JsonCompare.get_diff(old, new, {})
+      result.should eq({
+        :update => {
+          0 => {:update => {id: '456'}}
+        }
+      })
+    end
+
+    it "should treat as remove and append" do
+      old = [{id: '123'}]
+      new = [{id: '456'}]
+      result = JsonCompare.get_diff(old, new, {matching_key: :id})
+      result.should eq({
+        :remove => {
+          0 => {id: '123'}
+        },
+        :append => {
+          0 => {id: '456'}
+        }
+      })
+    end
+
+    it "should treat as remove and append" do
+      old = [{id: '123'}]
+      new = [{id: '456'}, {id: '123', internal: true}, {id: '789'}]
+      result = JsonCompare.get_diff(old, new, {matching_key: :id})
+      result.should eq({
+        :update => {
+          0 => {
+            :append => {internal: true}
+          }
+        },
+        :append => {
+          0 => {id: '456'},
+          2 => {id: '789'}
+        }
+      })
+    end
+
+    it "should follow the array's order when comparing" do
+      old = [{id: '123'}, {id: '456'}]
+      new = [{id: '456'}, {id: '123'}]
+      result = JsonCompare.get_diff(old, new, {matching_key: :id})
+      result.should eq({
+        :append => {
+          0 => {id: '456'}
+        },
+        :remove => {
+          1 => {id: '456'}
+        }
+      })
+    end
+  end
+
+  describe 'Hash Array Comparison' do
+    it "should return empty hash" do
+      old_hash = {"ID" => "123"}
+      new_array = [{"ID" => "123"}]
+      result = JsonCompare.get_diff(old_hash, new_array)
+      result.should eq({})
+    end
+
+    it "should consider new array elements as append" do
+      old_hash = {"ID" => "123"}
+      new_array = [{"ID" => "123"}, {"ID" => "456"}]
+      result = JsonCompare.get_diff(old_hash, new_array)
+      result.should eq({
+        :append => {
+          1 => {"ID" => "456"}
+        }
+      })
     end
   end
 

--- a/spec/lib/json-compare_spec.rb
+++ b/spec/lib/json-compare_spec.rb
@@ -136,57 +136,57 @@ describe 'Json compare' do
 
   describe 'Arrays Comparison with matching condition' do
     it "should treat as update" do
-      old = [{id: '123'}]
-      new = [{id: '456'}]
+      old = [{:id => '123'}]
+      new = [{:id => '456'}]
       result = JsonCompare.get_diff(old, new, {})
       result.should eq({
         :update => {
-          0 => {:update => {id: '456'}}
+          0 => {:update => {:id => '456'}}
         }
       })
     end
 
     it "should treat as remove and append" do
-      old = [{id: '123'}]
-      new = [{id: '456'}]
-      result = JsonCompare.get_diff(old, new, {matching_key: :id})
+      old = [{:id => '123'}]
+      new = [{:id => '456'}]
+      result = JsonCompare.get_diff(old, new, {:matching_key => :id})
       result.should eq({
         :remove => {
-          0 => {id: '123'}
+          0 => {:id => '123'}
         },
         :append => {
-          0 => {id: '456'}
+          0 => {:id => '456'}
         }
       })
     end
 
     it "should treat as remove and append" do
-      old = [{id: '123'}]
-      new = [{id: '456'}, {id: '123', internal: true}, {id: '789'}]
-      result = JsonCompare.get_diff(old, new, {matching_key: :id})
+      old = [{:id => '123'}]
+      new = [{:id => '456'}, {:id => '123', :internal => true}, {:id => '789'}]
+      result = JsonCompare.get_diff(old, new, {:matching_key => :id})
       result.should eq({
         :update => {
           0 => {
-            :append => {internal: true}
+            :append => {:internal => true}
           }
         },
         :append => {
-          0 => {id: '456'},
-          2 => {id: '789'}
+          0 => {:id => '456'},
+          2 => {:id => '789'}
         }
       })
     end
 
     it "should follow the array's order when comparing" do
-      old = [{id: '123'}, {id: '456'}]
-      new = [{id: '456'}, {id: '123'}]
-      result = JsonCompare.get_diff(old, new, {matching_key: :id})
+      old = [{:id => '123'}, {:id => '456'}]
+      new = [{:id => '456'}, {:id => '123'}]
+      result = JsonCompare.get_diff(old, new, {:matching_key => :id})
       result.should eq({
         :append => {
-          0 => {id: '456'}
+          0 => {:id => '456'}
         },
         :remove => {
-          1 => {id: '456'}
+          1 => {:id => '456'}
         }
       })
     end


### PR DESCRIPTION
When comparing the following two arrays:
  array1 = [{id: 123, color: 'green'}, {id: 456, color: 'red'}]
  array2 = [{id: 123, color: 'green'}, {id: 789, color: 'blue'}]
Instead of a result {:update => {1: {:update => {id: 789, color: 'blue'}}}}
What you get by passing the :id as the matching key
{:remove => {1: {id: 456, color: 'red'}}, :append => {1: {id: 789, color: 'blue'}}}
