### PR TITLE
Bug fix filter results

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+= 0.1.9
+
+ * FIX: fixed filter_results method from removing diffs of non-integer keys that have nil values (Ken Sharpeta)
+
 = 0.1.8
 
  * FIX: comparing a String with a Fixnum (Marc Neumann)

--- a/lib/json-compare/comparer.rb
+++ b/lib/json-compare/comparer.rb
@@ -108,7 +108,7 @@ module JsonCompare
         next if result[change_type].nil?
         temp_hash = {}
         result[change_type].each_key do |key|
-          next if result[change_type][key].nil?
+          next if result[change_type][key].nil? && key.is_a?(Integer)
           next if @excluded_keys.include? key
           temp_hash[key] = result[change_type][key]
         end

--- a/lib/json-compare/version.rb
+++ b/lib/json-compare/version.rb
@@ -1,3 +1,3 @@
 module JsonCompare
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end

--- a/spec/fixtures/testfix0.1.9_1.json
+++ b/spec/fixtures/testfix0.1.9_1.json
@@ -1,0 +1,22 @@
+{
+  "status": "success",
+  "records": [
+    {
+      "status": "Renewed",
+      "reissuable": true,
+      "private_key": "PRIVATEKEYTEST",
+      "certificate": null,
+      "chain": null,
+      "order_number": 11111111,
+      "applicant": "Joe Shmo",
+      "registration": null,
+      "host": "HOSTTEST",
+      "created_date": "2016-06-22T20:35:54Z",
+      "license_key": null,
+      "password": null,
+      "applicant_email": "joe.shmo@company.com",
+      "id": "a0Aa00000044oinAAA",
+      "csr": "CSRTEST"
+    }
+  ]
+}

--- a/spec/fixtures/testfix0.1.9_2.json
+++ b/spec/fixtures/testfix0.1.9_2.json
@@ -1,0 +1,23 @@
+{
+  "status": "success",
+  "records": [
+    {
+      "applicant": "Joe Shmo",
+      "applicant_email": "joe.shmo@company.com",
+      "certificate": null,
+      "chain": null,
+      "created_date": "2016-06-22 20:35:54",
+      "expiry_date": "2016-07-22",
+      "expires_soon": "yes",
+      "host": "HOSTTEST",
+      "id": "a0Aa00000044oinAAA",
+      "license": null,
+      "order_number": 11111111,
+      "password": null,
+      "private_key": "PRIVATEKEYTEST",
+      "registration": "1970-01-01",
+      "reissuable": "no",
+      "status": "Renewed"
+    }
+  ]
+}

--- a/spec/lib/json-compare_spec.rb
+++ b/spec/lib/json-compare_spec.rb
@@ -163,4 +163,38 @@ describe 'Json compare' do
       result.should eq(expected)
     end
   end
+
+  describe "filter results" do
+    it "should not filter out non-integer keys that have a nil value" do
+      json1 = File.new('spec/fixtures/testfix0.1.9_1.json', 'r')
+      json2 = File.new('spec/fixtures/testfix0.1.9_2.json', 'r')
+      old, new = Yajl::Parser.parse(json1), Yajl::Parser.parse(json2)
+      result = JsonCompare.get_diff(old, new)
+      expected = {
+        :update=>{
+          "records"=>{
+            :update=>{
+              0=>{
+                :append=>{
+                  "expiry_date"=>"2016-07-22",
+                  "expires_soon"=>"yes",
+                  "license"=>nil
+                  },
+                  :remove=>{
+                    "license_key"=>nil,
+                    "csr"=>"CSRTEST"
+                    },
+                    :update=>{
+                      "reissuable"=>"no",
+                      "registration"=>"1970-01-01",
+                      "created_date"=>"2016-06-22 20:35:54"
+                    }
+                  }
+                }
+              }
+            }
+          }
+          result.should eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
Hello!

I found that "license" => nil vs. "license_key" => nil was not being detected in the result.  Added an Integer check of the key in the filter_results method, because it appeared that it was trying to skip the indexes of arrays that were nil (0 => nil, 1 => nil), not actually trying to skip all keys with nil values ("license" => nil, "license_key" => nil).

I added a test for the scenario and all previous tests still are passing.

Let me know if there are any questions or concerns.

Ken